### PR TITLE
Create delete function

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -28,12 +28,18 @@ class TasksController < ApplicationController
 
   def update
     @task = Task.find(params[:id])
-    
+
     if @task.update(task_params)
-      redirect_to task_path(@task), notice: "タスク「#{@task.name}」を更新しました。"
+      redirect_to tasks_path, notice: "タスク「#{@task.name}」を更新しました。"
     else
       render :action => "edit"
     end
+  end
+
+  def destroy
+    @task = Task.find(params[:id])
+    @task.destroy
+    redirect_to tasks_path, notice: "タスク#{@task.name}を削除しました"
   end
 
   private

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -4,18 +4,18 @@ h1 タスクの編集
  = link_to '一覧', tasks_path, class: 'nav-link'
 
 .container
- = form_with model: @task, local: true do |f|
-   .form-group
-     = f.label :name
-     = f.text_field :name, class: 'form-control', id: 'task_name'
-   .form-group
-     = f.label :description
-     = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
-   .form-group
-       = f.label :priority
-       = f.select :priority,{"高": 1,"中": 2,"低": 3}, id: 'task_priority'
-   .form-group
-       = f.label :deadline
-       = f.date_select :deadline, id: 'task_deadline'
+  = form_with model: @task, local: true do |f|
+    .form-group
+      = f.label :name
+      = f.text_field :name, class: 'form-control', id: 'task_name'
+    .form-group
+      = f.label :description
+      = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
+    .form-group
+      = f.label :priority
+      = f.select :priority,{"高": 1,"中": 2,"低": 3}, id: 'task_priority'
+    .form-group
+      = f.label :deadline
+      = f.date_select :deadline, id: 'task_deadline'
 
-   = f.submit "更新", class: 'btn btn-primary'
+    = f.submit "更新", class: 'btn btn-primary'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -11,6 +11,7 @@ table.table.table-striped
       th= Task.human_attribute_name(:deadline)
       th= Task.human_attribute_name(:priority)
       th= Task.human_attribute_name(:status)
+      th
 
   tbody
     -@tasks.each do |task|
@@ -20,3 +21,4 @@ table.table.table-striped
         td=  task.deadline
         td=  task.priority
         td=  task.status
+        td= link_to '削除', task_path(task), method: :delete, data: { confirm: "タスク「#{task.name}」を削除してよろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -27,3 +27,4 @@ table.table.table-hover
       th= Task.human_attribute_name(:updated_at)
       td= @task.updated_at
 = link_to '編集', edit_task_path(@task), class: 'btn btn-primary mr-3'
+= link_to '削除', task_path(@task), method: :delete, data: { confirm: "タスク「#{@task.name}」を削除してよろしいですか？" }, class: 'btn btn-danger'


### PR DESCRIPTION
## 処理概要
タスクの削除機能を実装しました。

## 要件・仕様
タスク一覧画面と詳細画面にてタスクの削除ボタンを配置。

link_toにdeleteメソッドを指定して、destroyアクションに飛ぶようになっています。