### PR TITLE
エラーハンドリングの追加

### DIFF
--- a/app/controllers/concerns/error_handlers.rb
+++ b/app/controllers/concerns/error_handlers.rb
@@ -2,7 +2,12 @@ module ErrorHandlers
   extend ActiveSupport::Concern
 
   included do
+    rescue_from Exception, with: :rescue500
     rescue_from ApplicationController::Forbidden, with: :rescue403
+
+    def rescue404
+      render 'errors/not_found', status: 404
+    end
   end
 
   private
@@ -10,5 +15,10 @@ module ErrorHandlers
   def rescue403(e)
     @exception = e
     render 'errors/forbidden', status: 403
+  end
+
+  def rescue500(e)
+    @exception = e
+    render '/errors/internal_server_error', status: 500
   end
 end

--- a/app/views/errors/internal_server_error.html.slim
+++ b/app/views/errors/internal_server_error.html.slim
@@ -1,0 +1,3 @@
+#errors
+  h1 500 internal server error
+  p 内部サーバーエラー

--- a/app/views/errors/not_found.html.slim
+++ b/app/views/errors/not_found.html.slim
@@ -1,0 +1,3 @@
+#errors
+  h1 404 not found error
+  p ページが見つかりません

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,6 @@ Rails.application.routes.draw do
 
   root to: "tasks#index"
   resources :tasks
+  get '*anything', to: "application#rescue404"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
## 処理概要
エラーハンドリングの追加

## 参考
- rescue_fromの走る順番
https://qiita.com/ms2sato/items/249ec3aa186dd42176fb
- routing_errorはraiseで捕らえられない
https://joe41203.hatenablog.com/entry/2018/07/11/003242

## 特記
複雑な処理が含まれる場合は、設計・実装方針を記載してください
※ コードにコメントと言う形での記載も可

## 動作確認観点
- tasks_controrllerにraise StandardErrorを記載した際のレンダリング(500error)
![7064b4de12b122b815ccb97a030cfb7a](https://user-images.githubusercontent.com/48540301/78882746-77fbe700-7a93-11ea-9827-400a006af659.gif)
- 403error
![de442e20ae85e2147255799c0d5910c5](https://user-images.githubusercontent.com/48540301/78882917-be514600-7a93-11ea-8245-aa868b2f6429.gif)
- 404error
![fe038903da6ef5d7d3828d9e939c07f7](https://user-images.githubusercontent.com/48540301/78883003-e0e35f00-7a93-11ea-986e-97f09134cf7a.gif)
